### PR TITLE
macOS support

### DIFF
--- a/src/matrix/notify.rs
+++ b/src/matrix/notify.rs
@@ -1,6 +1,4 @@
 use log::error;
-#[cfg(not(target_os = "macos"))]
-use log::info;
 use matrix_sdk::ruma::UserId;
 use matrix_sdk::ruma::{OwnedRoomId, events::AnyTimelineEvent};
 use std::fs::OpenOptions;
@@ -23,15 +21,6 @@ use matrix_sdk::{
     media::MediaFormat,
     room::{Room, RoomMember},
 };
-#[cfg(not(target_os = "macos"))]
-use notify_rust::{CloseReason, Hint};
-
-#[cfg(not(target_os = "macos"))]
-use crate::app::App;
-#[cfg(not(target_os = "macos"))]
-use crate::settings::respect_notification_close_reason;
-#[cfg(not(target_os = "macos"))]
-use crate::handler::MatuiEvent;
 use crate::{settings::is_muted, widgets::message::Message};
 
 pub struct Notify {
@@ -103,19 +92,23 @@ impl Notify {
     }
 
     pub fn room_visit_event(&self, room: Room) {
-        let mut map = self.rooms.lock().expect("could not lock rooms");
+        self.close_notification(room.room_id().as_str());
+        *self.room_id.lock().unwrap() = Some(room.room_id().to_owned());
+    }
 
-        #[cfg(not(target_os = "macos"))]
-        if let Some(handle_id) = map.remove(room.room_id().as_str())
+    #[cfg(not(target_os = "macos"))]
+    fn close_notification(&self, room_id: &str) {
+        let mut map = self.rooms.lock().expect("could not lock rooms");
+        if let Some(handle_id) = map.remove(room_id)
             && let Ok(handle) = notify_rust::Notification::new().id(handle_id).show()
         {
             handle.close();
         }
+    }
 
-        #[cfg(target_os = "macos")]
-        map.remove(room.room_id().as_str());
-
-        *self.room_id.lock().unwrap() = Some(room.room_id().to_owned());
+    #[cfg(target_os = "macos")]
+    fn close_notification(&self, room_id: &str) {
+        self.rooms.lock().expect("could not lock rooms").remove(room_id);
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -126,6 +119,12 @@ impl Notify {
         room: Room,
         image: Option<PathBuf>,
     ) -> anyhow::Result<()> {
+        use crate::app::App;
+        use crate::handler::MatuiEvent;
+        use crate::settings::respect_notification_close_reason;
+        use log::info;
+        use notify_rust::{CloseReason, Hint};
+
         let mut notification = notify_rust::Notification::new();
 
         notification.summary(summary).body(body);

--- a/src/matrix/notify.rs
+++ b/src/matrix/notify.rs
@@ -26,6 +26,7 @@ use matrix_sdk::{
 #[cfg(not(target_os = "macos"))]
 use notify_rust::{CloseReason, Hint};
 
+#[cfg(not(target_os = "macos"))]
 use crate::app::App;
 #[cfg(not(target_os = "macos"))]
 use crate::settings::respect_notification_close_reason;

--- a/src/matrix/notify.rs
+++ b/src/matrix/notify.rs
@@ -1,4 +1,6 @@
-use log::{error, info};
+use log::error;
+#[cfg(not(target_os = "macos"))]
+use log::info;
 use matrix_sdk::ruma::UserId;
 use matrix_sdk::ruma::{OwnedRoomId, events::AnyTimelineEvent};
 use std::fs::OpenOptions;
@@ -21,11 +23,15 @@ use matrix_sdk::{
     media::MediaFormat,
     room::{Room, RoomMember},
 };
+#[cfg(not(target_os = "macos"))]
 use notify_rust::{CloseReason, Hint};
 
 use crate::app::App;
+#[cfg(not(target_os = "macos"))]
 use crate::settings::respect_notification_close_reason;
-use crate::{handler::MatuiEvent, settings::is_muted, widgets::message::Message};
+#[cfg(not(target_os = "macos"))]
+use crate::handler::MatuiEvent;
+use crate::{settings::is_muted, widgets::message::Message};
 
 pub struct Notify {
     focus: AtomicBool,
@@ -98,15 +104,20 @@ impl Notify {
     pub fn room_visit_event(&self, room: Room) {
         let mut map = self.rooms.lock().expect("could not lock rooms");
 
+        #[cfg(not(target_os = "macos"))]
         if let Some(handle_id) = map.remove(room.room_id().as_str())
             && let Ok(handle) = notify_rust::Notification::new().id(handle_id).show()
         {
             handle.close();
         }
 
+        #[cfg(target_os = "macos")]
+        map.remove(room.room_id().as_str());
+
         *self.room_id.lock().unwrap() = Some(room.room_id().to_owned());
     }
 
+    #[cfg(not(target_os = "macos"))]
     fn send_notification(
         &self,
         summary: &str,
@@ -168,6 +179,21 @@ impl Notify {
             }
         });
 
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn send_notification(
+        &self,
+        summary: &str,
+        body: &str,
+        _room: Room,
+        _image: Option<PathBuf>,
+    ) -> anyhow::Result<()> {
+        notify_rust::Notification::new()
+            .summary(summary)
+            .body(body)
+            .show()?;
         Ok(())
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -6,17 +6,11 @@ use log::error;
 use matrix_sdk::media::MediaFileHandle;
 use native_dialog::DialogBuilder;
 use regex::Regex;
-#[cfg(not(target_os = "macos"))]
-use image::imageops::FilterType;
 use std::env::var;
 use std::fs;
-#[cfg(not(target_os = "macos"))]
-use std::io::Cursor;
 use std::io::stdout;
 use std::path::PathBuf;
 use std::process::Command;
-#[cfg(not(target_os = "macos"))]
-use notify_rust::Hint;
 use tempfile::Builder;
 
 use crate::app::App;
@@ -198,8 +192,12 @@ pub fn view_text(text: &str) {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 pub fn send_notification(summary: &str, body: &str, image: Option<Vec<u8>>) -> anyhow::Result<()> {
-    #[cfg(not(target_os = "macos"))]
+    use image::imageops::FilterType;
+    use notify_rust::Hint;
+    use std::io::Cursor;
+
     if let Some(img) = image {
         let data = Cursor::new(img);
         let reader = image::ImageReader::new(data).with_guessed_format()?;
@@ -217,15 +215,15 @@ pub fn send_notification(summary: &str, body: &str, image: Option<Vec<u8>>) -> a
         notify_rust::Notification::new().body(body).show()?;
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let _ = image;
-        notify_rust::Notification::new()
-            .summary(summary)
-            .body(body)
-            .show()?;
-    }
+    Ok(())
+}
 
+#[cfg(target_os = "macos")]
+pub fn send_notification(summary: &str, body: &str, _image: Option<Vec<u8>>) -> anyhow::Result<()> {
+    notify_rust::Notification::new()
+        .summary(summary)
+        .body(body)
+        .show()?;
     Ok(())
 }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,18 +1,22 @@
 use anyhow::{Context, bail};
 use crossterm::{event::EnableFocusChange, execute};
-use image::imageops::FilterType;
 use lazy_static::lazy_static;
 use linkify::LinkFinder;
 use log::error;
 use matrix_sdk::media::MediaFileHandle;
 use native_dialog::DialogBuilder;
-use notify_rust::Hint;
 use regex::Regex;
+#[cfg(not(target_os = "macos"))]
+use image::imageops::FilterType;
 use std::env::var;
 use std::fs;
-use std::io::{Cursor, stdout};
+#[cfg(not(target_os = "macos"))]
+use std::io::Cursor;
+use std::io::stdout;
 use std::path::PathBuf;
 use std::process::Command;
+#[cfg(not(target_os = "macos"))]
+use notify_rust::Hint;
 use tempfile::Builder;
 
 use crate::app::App;
@@ -195,6 +199,7 @@ pub fn view_text(text: &str) {
 }
 
 pub fn send_notification(summary: &str, body: &str, image: Option<Vec<u8>>) -> anyhow::Result<()> {
+    #[cfg(not(target_os = "macos"))]
     if let Some(img) = image {
         let data = Cursor::new(img);
         let reader = image::ImageReader::new(data).with_guessed_format()?;
@@ -210,6 +215,15 @@ pub fn send_notification(summary: &str, body: &str, image: Option<Vec<u8>>) -> a
             .show()?;
     } else {
         notify_rust::Notification::new().body(body).show()?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let _ = image;
+        notify_rust::Notification::new()
+            .summary(summary)
+            .body(body)
+            .show()?;
     }
 
     Ok(())


### PR DESCRIPTION
I managed to get it working on macOS without interfering with Linux support (I think!). Builds and runs great! Let me know if any other changes are necessary.

Short version of what changed:

- Gated the Linux/D-Bus-specific `notify-rust` APIs behind
  `#[cfg(not(target_os = "macos"))]`.
- Added simpler macOS notification paths that use the supported
  `notify-rust` calls on macOS.
- Kept the existing Linux notification behavior intact, including image hints
  and async close handling where those APIs are available.
- Added the `zbus` tokio feature override so the notification stack builds
  cleanly with the rest of the app.

Verified with:

```text
cargo check
cargo build
```
